### PR TITLE
refactor(software): shrink main.py from 376 to 263 lines and add characterization tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ log/
 vite.config.*.timestamp-*
 software/**/*.sw.json
 software/*.tgz
+software/.coverage
 # BUG in vue-tsc, it enables incremental builds when we do not ask it
 ui/tsconfig.app.tsbuildinfo
 ui/tsconfig.node.tsbuildinfo

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -1,0 +1,54 @@
+[project]
+name = "repertoire-distance-calc-script"
+version = "0.0.0"
+requires-python = ">=3.12.0, <3.13"
+
+[dependency-groups]
+dev = [
+    "pandas==2.2.3",
+    "numpy==2.2.6",
+    "scipy==1.15.3",
+    "pytest>=9.0.2",
+    "pytest-cov>=6.0.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = "-ra --strict-markers"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
+
+[tool.coverage.run]
+source = ["src"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]
+
+[tool.ruff]
+exclude = [
+    ".bzr", ".direnv", ".eggs", ".git", ".git-rewrite", ".hg",
+    ".ipynb_checkpoints", ".mypy_cache", ".nox", ".pants.d",
+    ".pyenv", ".pytest_cache", ".pytype", ".ruff_cache", ".svn",
+    ".tox", ".venv", ".vscode", "__pypackages__", "_build",
+    "buck-out", "build", "dist", "node_modules", "site-packages", "venv",
+]
+line-length = 120
+indent-width = 4
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "E501", "F", "I"]
+ignore = []
+fixable = ["ALL"]
+unfixable = []
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/software/src/main.py
+++ b/software/src/main.py
@@ -1,354 +1,263 @@
-import numpy as np
-import pandas as pd
 import argparse
 import json
 from collections import defaultdict
 from itertools import combinations_with_replacement, product
-from scipy.stats import linregress
+
+import numpy as np
+import pandas as pd
 from numpy.random import default_rng
+from scipy.stats import linregress
+
+INVALID_VDJ_VALUES = {"", "region_not_covered"}
+
 
 # ---------- Data Filtering ----------
 def filter_vdj_regions(df, is_single_cell_data):
-    """
-    Filter out rows where VDJ regions are empty/null or contain 'region_not_covered'
-    """
-    if is_single_cell_data:
-        # For single-cell data, check both A and B chain VDJ regions
-        vdj_columns = ['VGene_A', 'JGene_A', 'VGene_B', 'JGene_B']
-    else:
-        # For bulk data, check single-chain VDJ regions
-        vdj_columns = ['VGene', 'JGene']
-    
-    # Create mask for valid VDJ regions
+    """Drop rows where any relevant VDJ column is null, empty, or 'region_not_covered'."""
+    vdj_columns = ["VGene_A", "JGene_A", "VGene_B", "JGene_B"] if is_single_cell_data else ["VGene", "JGene"]
+
     valid_mask = pd.Series(True, index=df.index)
-    
     for col in vdj_columns:
         if col in df.columns:
-            # Filter out empty/null values and 'region_not_covered'
-            col_mask = (
-                df[col].notna() & 
-                (df[col] != '') & 
-                (df[col] != 'region_not_covered')
-            )
-            valid_mask = valid_mask & col_mask
-    
-    filtered_df = df[valid_mask].copy()
-    
-    return filtered_df
+            valid_mask &= df[col].notna() & ~df[col].isin(INVALID_VDJ_VALUES)
+
+    return df[valid_mask].copy()
+
 
 # ---------- Downsampling ----------
+def _hypergeometric_target(total_reads, downsampling_config):
+    """Resolve the per-sample read target for hypergeometric downsampling."""
+    value_chooser = downsampling_config.get("valueChooser", "auto")
+    if value_chooser == "auto":
+        threshold = 0.5 * np.quantile(total_reads, 0.2)
+        samples_above = total_reads[total_reads > threshold]
+        return int(samples_above.min()) if not samples_above.empty else 0
+    if value_chooser == "fixed":
+        return downsampling_config.get("n", 1000)
+    if value_chooser == "min":
+        return int(total_reads.min())
+    if value_chooser == "max":
+        return int(total_reads.max())
+    raise ValueError(f"Unsupported value chooser: {value_chooser}")
+
+
 def downsample_df(df, downsampling_config):
-    ds_type = downsampling_config['type']
+    """Return a new DataFrame with downsampling applied and fractionOfReads recomputed per sample."""
+    ds_type = downsampling_config["type"]
 
-    # total_reads is only needed by cumtop (as a map source) and hypergeometric (for the read target)
-    total_reads = df.groupby('sampleId')['numberOfreads'].sum() if ds_type in ('cumtop', 'hypergeometric') else None
-
-    if ds_type == 'none':
+    if ds_type == "none":
         df = df.copy()
-    elif ds_type == 'top':
-        n = downsampling_config.get('n', 1000)
-        df = df.sort_values('numberOfreads', ascending=False).groupby('sampleId').head(n)
-    elif ds_type == 'cumtop':
-        n = downsampling_config.get('n', 50)
-        df = df.sort_values('numberOfreads', ascending=False)
-        df['cumsum'] = df.groupby('sampleId')['numberOfreads'].cumsum()
-        df['total'] = df['sampleId'].map(total_reads)
-        df = df[df['cumsum'] <= df['total'] * (n / 100)]
-        df = df.drop(['cumsum', 'total'], axis=1)
-    elif ds_type == 'hypergeometric':
-        value_chooser = downsampling_config.get('valueChooser', 'auto')
-        if value_chooser == 'auto':
-            q20 = np.quantile(total_reads, 0.2)
-            threshold = 0.5 * q20
-            samples_above = total_reads[total_reads > threshold].index
-            min_reads = total_reads.loc[samples_above].min() if len(samples_above) > 0 else 0
-        elif value_chooser == 'fixed':
-            min_reads = downsampling_config.get('n', 1000)
-        elif value_chooser == 'min':
-            min_reads = total_reads.min()
-        elif value_chooser == 'max':
-            min_reads = total_reads.max()
-        else:
-            raise ValueError(f"Unsupported value chooser: {value_chooser}")
+    elif ds_type == "top":
+        n = downsampling_config.get("n", 1000)
+        df = df.sort_values("numberOfreads", ascending=False).groupby("sampleId").head(n)
+    elif ds_type == "cumtop":
+        n = downsampling_config.get("n", 50)
+        df = df.sort_values("numberOfreads", ascending=False).copy()
+        total_reads = df.groupby("sampleId")["numberOfreads"].sum()
+        cumsum = df.groupby("sampleId")["numberOfreads"].cumsum()
+        total = df["sampleId"].map(total_reads)
+        df = df[cumsum <= total * (n / 100)]
+    elif ds_type == "hypergeometric":
+        total_reads = df.groupby("sampleId")["numberOfreads"].sum()
+        min_reads = _hypergeometric_target(total_reads, downsampling_config)
 
         rng = default_rng(12345)
         downsampled = []
-        for sid in sorted(df['sampleId'].unique()):
-            sample_df = df[df['sampleId'] == sid]
-            counts = sample_df['numberOfreads'].values
-            sampled_counts = rng.multivariate_hypergeometric(counts, min_reads) if counts.sum() > min_reads else counts
-            sample_df = sample_df.copy()
-            sample_df['numberOfreads'] = sampled_counts
+        for sid, sample_df in sorted(df.groupby("sampleId")):
+            counts = sample_df["numberOfreads"].to_numpy()
+            if counts.sum() > min_reads:
+                counts = rng.multivariate_hypergeometric(counts, min_reads)
+            sample_df = sample_df.assign(numberOfreads=counts)
             downsampled.append(sample_df)
 
         df = pd.concat(downsampled, ignore_index=True)
     else:
         raise ValueError(f"Unsupported downsampling type: {ds_type}")
 
-    df['fractionOfReads'] = df.groupby('sampleId')['numberOfreads'].transform(lambda x: x / x.sum())
+    df["fractionOfReads"] = df["numberOfreads"] / df.groupby("sampleId")["numberOfreads"].transform("sum")
     return df
 
+
 # ---------- Clone Key Builder ----------
-def make_clone_key(row, intersection_type, is_single_cell_data):
-    if is_single_cell_data:
-        # Single-cell data: always use both chains for these intersection types
-        if intersection_type == 'CDR3ntVJ':
-            return f"{row['CDR3nt_A']}|{row['CDR3nt_B']}|{row['VGene_A']}|{row['VGene_B']}|{row['JGene_A']}|{row['JGene_B']}"
-        elif intersection_type == 'CDR3aaVJ':
-            return f"{row['CDR3aa_A']}|{row['CDR3aa_B']}|{row['VGene_A']}|{row['VGene_B']}|{row['JGene_A']}|{row['JGene_B']}"
-        elif intersection_type == 'CDR3nt':
-            return f"{row['CDR3nt_A']}|{row['CDR3nt_B']}"
-        elif intersection_type == 'CDR3aa':
-            return f"{row['CDR3aa_A']}|{row['CDR3aa_B']}"
-        else:
-            raise ValueError(f"Unsupported intersection_type for single-cell data: {intersection_type}")
-    else:
-        # Bulk data: use single-chain columns
-        if intersection_type == 'CDR3ntVJ':
-            return f"{row['CDR3nt']}|{row['VGene']}|{row['JGene']}"
-        elif intersection_type == 'CDR3aaVJ':
-            return f"{row['CDR3aa']}|{row['VGene']}|{row['JGene']}"
-        elif intersection_type == 'CDR3nt':
-            return row['CDR3nt']
-        elif intersection_type == 'CDR3aa':
-            return row['CDR3aa']
-        else:
-            raise ValueError(f"Unsupported intersection_type for bulk data: {intersection_type}")
+# (is_single_cell, intersection_type) -> ordered list of columns to join with '|'
+_CLONE_KEY_COLUMNS = {
+    (True, "CDR3ntVJ"): ["CDR3nt_A", "CDR3nt_B", "VGene_A", "VGene_B", "JGene_A", "JGene_B"],
+    (True, "CDR3aaVJ"): ["CDR3aa_A", "CDR3aa_B", "VGene_A", "VGene_B", "JGene_A", "JGene_B"],
+    (True, "CDR3nt"): ["CDR3nt_A", "CDR3nt_B"],
+    (True, "CDR3aa"): ["CDR3aa_A", "CDR3aa_B"],
+    (False, "CDR3ntVJ"): ["CDR3nt", "VGene", "JGene"],
+    (False, "CDR3aaVJ"): ["CDR3aa", "VGene", "JGene"],
+    (False, "CDR3nt"): ["CDR3nt"],
+    (False, "CDR3aa"): ["CDR3aa"],
+}
+
+
+def build_clone_keys(df, intersection_type, is_single_cell_data):
+    """Vectorized clone-key builder — returns a Series of '|'-joined keys aligned with df's index."""
+    try:
+        cols = _CLONE_KEY_COLUMNS[(is_single_cell_data, intersection_type)]
+    except KeyError:
+        kind = "single-cell data" if is_single_cell_data else "bulk data"
+        raise ValueError(f"Unsupported intersection_type for {kind}: {intersection_type}")
+    if len(cols) == 1:
+        return df[cols[0]].astype(str)
+    parts = [df[c].astype(str) for c in cols]
+    return parts[0].str.cat(parts[1:], sep="|")
+
 
 # ---------- Metric Calculation ----------
 def compute_metric(s1, s2, clones1, clones2, set1, set2, metric):
+    # Self-pair short-circuit: similarity metrics return 1.0 by convention; shared-count returns cloneset size
     if s1 == s2:
-        # Self-pair → perfect match
-        if metric in ['F1', 'F2', 'jaccard', 'correlation', 'D']:
-            return 1.0
-        elif metric == 'sharedClonotypes':
+        if metric == "sharedClonotypes":
             return len(set1)
-        else:
-            raise ValueError(f"Unsupported metric: {metric}")
+        if metric in ("F1", "F2", "jaccard", "correlation", "D"):
+            return 1.0
+        raise ValueError(f"Unsupported metric: {metric}")
 
     shared = set1 & set2
-    if len(shared) == 0:
+    if not shared:
         return 0.0
 
-    # Sort shared keys to ensure deterministic ordering for correlation calculations
-    shared_sorted = sorted(shared)
-    f1 = np.array([clones1[k] for k in shared_sorted])
-    f2 = np.array([clones2[k] for k in shared_sorted])
+    # Sorted for deterministic ordering in correlation math
+    keys = sorted(shared)
+    f1 = np.array([clones1[k] for k in keys])
+    f2 = np.array([clones2[k] for k in keys])
 
-    if metric == 'F1':
+    if metric == "F1":
         return np.sqrt(f1.sum() * f2.sum())
-    elif metric == 'F2':
+    if metric == "F2":
         return np.sqrt(f1 * f2).sum()
-    elif metric == 'jaccard':
+    if metric == "jaccard":
         return len(shared) / len(set1 | set2)
-    elif metric == 'D':
-        # This D metric is defined as |intersection| / (|set1| * |set2|)
+    if metric == "D":  # |intersection| / (|set1| * |set2|)
         return len(shared) / (len(set1) * len(set2))
-    elif metric == 'correlation':
+    if metric == "sharedClonotypes":
+        return len(shared)
+    if metric == "correlation":
         if len(shared) <= 1 or np.all(f1 == f1[0]) or np.all(f2 == f2[0]):
             return 1.0 if np.all(f1 == f2) else 0.0
         return linregress(f1, f2).rvalue
-    elif metric == 'sharedClonotypes':
-        return len(shared)
-    else:
-        raise ValueError(f"Unsupported metric: {metric}")
+    raise ValueError(f"Unsupported metric: {metric}")
+
 
 # ---------- Main Processing ----------
 def compute_metrics_wide(df_original, metric_configs, is_single_cell_data):
-    sample_ids = sorted(df_original['sampleId'].unique())
-
-    # All sample × sample pairs
+    sample_ids = sorted(df_original["sampleId"].unique())
     all_output_pairs = list(product(sample_ids, repeat=2))
     unique_pairs = list(combinations_with_replacement(sample_ids, 2))
 
-    # Group metrics by intersection type and downsampling config
+    # Group metrics by (intersection, downsampling config) so we can share downsampled frames
     metrics_by_config = defaultdict(list)
     for i, config in enumerate(metric_configs):
-        # Create a key that includes both intersection and downsampling config
-        config_key = (config['intersection'], json.dumps(config['downsampling'], sort_keys=True))
-        metrics_by_config[config_key].append((config['type'], i))
+        config_key = (config["intersection"], json.dumps(config["downsampling"], sort_keys=True))
+        metrics_by_config[config_key].append((config["type"], i))
 
-    # Cache for downsampled datasets
     downsampled_cache = {}
-
     results = {}
 
-    # Sort config keys to ensure deterministic processing order
+    # Sorted for deterministic processing order
     for (intersection, downsampling_json), metric_list in sorted(metrics_by_config.items()):
-        # Parse the downsampling config
-        downsampling_config = json.loads(downsampling_json)
-        
-        # Check if we already have this downsampling config cached
         if downsampling_json not in downsampled_cache:
-            # Apply downsampling for this specific configuration and cache it
-            df_down = downsample_df(df_original, downsampling_config)
-            downsampled_cache[downsampling_json] = df_down
-        else:
-            # Use cached downsampled dataset
-            df_down = downsampled_cache[downsampling_json]
-        
-        # Step 1: build cloneKey once
-        df = df_down.copy()
-        df['cloneKey'] = df.apply(lambda row: make_clone_key(row, intersection, is_single_cell_data), axis=1)
-        df = df[['sampleId', 'cloneKey', 'fractionOfReads']].rename(columns={'fractionOfReads': 'cloneFraction'})
+            downsampled_cache[downsampling_json] = downsample_df(df_original, json.loads(downsampling_json))
+        df_down = downsampled_cache[downsampling_json]
 
-        # Build sample_clone_dict in deterministic order (sorted by sampleId)
-        sample_clone_dict = {}
-        for sid in sample_ids:
-            sample_df = df[df['sampleId'] == sid]
-            if len(sample_df) > 0:
-                sample_clone_dict[sid] = sample_df.set_index('cloneKey')['cloneFraction'].to_dict()
-            else:
-                sample_clone_dict[sid] = {}
-        sample_cloneset_dict = {sid: set(clones.keys()) for sid, clones in sample_clone_dict.items()}
+        # Step 1: build cloneKey once (vectorized — avoids per-row Python apply)
+        df = df_down[["sampleId", "fractionOfReads"]].rename(columns={"fractionOfReads": "cloneFraction"}).copy()
+        df["cloneKey"] = build_clone_keys(df_down, intersection, is_single_cell_data)
 
-        for sid in sample_ids:
-            # Ensure all sample_ids are present in dictionaries, even if they have no clones
-            sample_clone_dict.setdefault(sid, {})
-            sample_cloneset_dict.setdefault(sid, set())
+        # Build {sampleId: {cloneKey: cloneFraction}} with one groupby pass; empty samples default to {}
+        sample_clone_dict = {sid: {} for sid in sample_ids}
+        for sid, group in df.groupby("sampleId"):
+            sample_clone_dict[sid] = dict(zip(group["cloneKey"], group["cloneFraction"]))
 
-        # Step 2: compute each metric only once per unique unordered pair
-        # Sort metric_list by original index to ensure deterministic processing order
-        metric_list_sorted = sorted(metric_list, key=lambda x: x[1])
-        metric_values = {metric: {} for metric, _ in metric_list_sorted}
+        # Step 2: compute each metric once per unique unordered pair; fill ordered pairs via symmetry
+        sorted_metrics = [m for m, _ in sorted(metric_list, key=lambda x: x[1])]
+        metric_values = {m: {} for m in sorted_metrics}
 
         for s1, s2 in unique_pairs:
             c1, c2 = sample_clone_dict[s1], sample_clone_dict[s2]
-            set1, set2 = sample_cloneset_dict[s1], sample_cloneset_dict[s2]
-
-            for metric, _ in metric_list_sorted:
-                val = compute_metric(s1, s2, c1, c2, set1, set2, metric)
+            for metric in sorted_metrics:
+                val = compute_metric(s1, s2, c1, c2, c1.keys(), c2.keys(), metric)
                 metric_values[metric][(s1, s2)] = val
                 if s1 != s2:
                     metric_values[metric][(s2, s1)] = val
 
         # Step 3: populate results
         for s1, s2 in all_output_pairs:
-            key = (s1, s2)
-            if key not in results:
-                results[key] = {'sample1': s1, 'sample2': s2}
-            for metric, _ in metric_list_sorted:
-                metric_col = f"{metric} {intersection}"
-                results[key][metric_col] = metric_values[metric].get((s1, s2), 0.0)
+            row = results.setdefault((s1, s2), {"sample1": s1, "sample2": s2})
+            for metric in sorted_metrics:
+                row[f"{metric} {intersection}"] = metric_values[metric].get((s1, s2), 0.0)
 
     return pd.DataFrame(results.values())
 
 
 # ---------- Empty Output Creation ----------
-def create_empty_outputs(metric_configs, output_full_path, sep):
-    """
-    Create empty output files with correct column structure when input is empty
-    """
-    # Create empty long format DataFrame
-    long_columns = ['sample1', 'sample2', 'metric', 'value']
-    empty_long_df = pd.DataFrame(columns=long_columns)
-    
-    # Save empty file
-    empty_long_df.to_csv(output_full_path, index=False, sep=sep)
+def create_empty_outputs(output_full_path, sep):
+    """Write an empty long-format TSV when input is empty."""
+    pd.DataFrame(columns=["sample1", "sample2", "metric", "value"]).to_csv(output_full_path, index=False, sep=sep)
 
 
 # ---------- CLI Entry ----------
 def main():
-    parser = argparse.ArgumentParser(description="Downsample and compute wide-format clonotype distances between samples, supporting both bulk and single-cell dual-chain data.")
-    parser.add_argument('-i', '--input', required=True, help="Input TSV or CSV file")
-    parser.add_argument('-j', '--json', required=True, help="JSON config: [{intersection: ..., type: ..., downsampling: ...}]")
-    parser.add_argument('-o1', '--output_full', required=True, help="Output CSV file with all sample pairs (matrix-friendly)")
-    parser.add_argument('--sep', default=None, help="Field separator (default auto-detect: CSV=',' or TSV='\\t')")
+    parser = argparse.ArgumentParser(
+        description="Compute clonotype distance metrics between samples (bulk or single-cell dual-chain)."
+    )
+    parser.add_argument("-i", "--input", required=True, help="Input TSV or CSV file")
+    parser.add_argument("-j", "--json", required=True, help="JSON config: [{intersection, type, downsampling}]")
+    parser.add_argument("-o1", "--output_full", required=True, help="Output TSV (long-format, all sample pairs)")
+    parser.add_argument("--sep", default=None, help="Field separator (auto: CSV=',' / TSV='\\t')")
 
     args = parser.parse_args()
-    sep = args.sep or ('\t' if args.input.endswith('.tsv') else ',')
+    sep = args.sep or ("\t" if args.input.endswith(".tsv") else ",")
 
-    # Load metric config JSON first to determine output structure
-    with open(args.json, 'r') as f:
+    with open(args.json, "r") as f:
         metric_configs = json.load(f)
 
-    # Check if input file is empty or has no data
     try:
         df = pd.read_csv(args.input, sep=sep)
         if df.empty:
-            # Create empty output file with correct column structure
-            create_empty_outputs(metric_configs, args.output_full, sep)
+            create_empty_outputs(args.output_full, sep)
             return
     except (pd.errors.EmptyDataError, FileNotFoundError):
-        # Handle empty file or file not found
-        create_empty_outputs(metric_configs, args.output_full, sep)
+        create_empty_outputs(args.output_full, sep)
         return
 
-    # Clean and normalize column names
-    df.columns = [col.strip().replace('"', '').replace(' ', '') for col in df.columns]
-    
-    # Attempt to detect if it's single-cell dual-chain data based on column presence
-    # Check for both A and B chain columns to ensure complete single-cell data
-    single_cell_a_chain_cols = {'CDR3aaA', 'CDR3ntA', 'VGeneA', 'JGeneA'}
-    single_cell_b_chain_cols = {'CDR3aaB', 'CDR3ntB', 'VGeneB', 'JGeneB'}
-    
-    a_chain_present = single_cell_a_chain_cols.issubset(df.columns)
-    b_chain_present = single_cell_b_chain_cols.issubset(df.columns)
-    
-    is_single_cell_data = False
-    if a_chain_present and b_chain_present:
-        # Complete single-cell dual-chain data detected
-        is_single_cell_data = True
-        # Rename single-cell columns to standardized internal names (_A, _B suffix)
-        df.rename(columns={
-            'CDR3aaA': 'CDR3aa_A', 'CDR3ntA': 'CDR3nt_A', 'VGeneA': 'VGene_A', 'JGeneA': 'JGene_A',
-            'CDR3aaB': 'CDR3aa_B', 'CDR3ntB': 'CDR3nt_B', 'VGeneB': 'VGene_B', 'JGeneB': 'JGene_B',
-            'count': 'numberOfreads'
-        }, inplace=True)
-        # Ensure all required A and B chain columns are present
-        required_cols = {
-            'sampleId', 'numberOfreads',
-            'CDR3aa_A', 'CDR3nt_A', 'VGene_A', 'JGene_A',
-            'CDR3aa_B', 'CDR3nt_B', 'VGene_B', 'JGene_B'
-        }
-    elif a_chain_present and not b_chain_present:
-        # Only A-chain columns present - treat as bulk data using A-chain
-        df.rename(columns={
-            'CDR3aaA': 'CDR3aa', 'CDR3ntA': 'CDR3nt', 'VGeneA': 'VGene', 'JGeneA': 'JGene',
-            'count': 'numberOfreads'
-        }, inplace=True)
-        required_cols = {'sampleId', 'numberOfreads', 'CDR3aa', 'CDR3nt', 'VGene', 'JGene'}
-    elif b_chain_present and not a_chain_present:
-        # Only B-chain columns present - treat as bulk data using B-chain
-        df.rename(columns={
-            'CDR3aaB': 'CDR3aa', 'CDR3ntB': 'CDR3nt', 'VGeneB': 'VGene', 'JGeneB': 'JGene',
-            'count': 'numberOfreads'
-        }, inplace=True)
-        required_cols = {'sampleId', 'numberOfreads', 'CDR3aa', 'CDR3nt', 'VGene', 'JGene'}
+    df.columns = [col.strip().replace('"', "").replace(" ", "") for col in df.columns]
+
+    # Detect chain columns to choose bulk vs single-cell processing. A+B present → single-cell
+    # dual-chain; only one chain → treat as bulk using that chain; neither → assume standard
+    # bulk columns already present.
+    a_cols = {"CDR3aaA": "CDR3aa_A", "CDR3ntA": "CDR3nt_A", "VGeneA": "VGene_A", "JGeneA": "JGene_A"}
+    b_cols = {"CDR3aaB": "CDR3aa_B", "CDR3ntB": "CDR3nt_B", "VGeneB": "VGene_B", "JGeneB": "JGene_B"}
+    has_a = set(a_cols).issubset(df.columns)
+    has_b = set(b_cols).issubset(df.columns)
+    is_single_cell_data = has_a and has_b
+
+    if is_single_cell_data:
+        rename_map = {**a_cols, **b_cols}
+        required_cols = {"sampleId", "numberOfreads", *a_cols.values(), *b_cols.values()}
+    elif has_a or has_b:
+        src = a_cols if has_a else b_cols
+        rename_map = {k: v[:-2] for k, v in src.items()}  # strip the "_A"/"_B" suffix
+        required_cols = {"sampleId", "numberOfreads", "CDR3aa", "CDR3nt", "VGene", "JGene"}
     else:
-        # Assume bulk data, rename original columns
-        df.rename(columns={
-            'CDR3aa': 'CDR3aa', # No change, but good to list for clarity
-            'CDR3nt': 'CDR3nt', # No change
-            'count': 'numberOfreads',
-            'VGene': 'VGene', # No change
-            'JGene': 'JGene' # No change
-        }, inplace=True)
-        # Ensure all required bulk columns are present
-        required_cols = {'sampleId', 'numberOfreads', 'CDR3aa', 'CDR3nt', 'VGene', 'JGene'}
+        rename_map = {}
+        required_cols = {"sampleId", "numberOfreads", "CDR3aa", "CDR3nt", "VGene", "JGene"}
+
+    df.rename(columns={**rename_map, "count": "numberOfreads"}, inplace=True)
 
     if not required_cols.issubset(df.columns):
-        raise ValueError(f"Missing required columns. Expected for data type detected: {required_cols - set(df.columns)}")
+        raise ValueError(
+            f"Missing required columns. Expected for data type detected: {required_cols - set(df.columns)}"
+        )
 
-    # Filter out rows with invalid VDJ regions
     df = filter_vdj_regions(df, is_single_cell_data)
-
-    # Apply downsampling for each metric configuration individually
     wide_result_df = compute_metrics_wide(df, metric_configs, is_single_cell_data)
 
-    # Convert wide format to long format for full results
-    value_columns = [f"{m['type']} {m['intersection']}" for m in metric_configs]
-    full_result_df = pd.melt(
-        wide_result_df,
-        id_vars=['sample1', 'sample2'],
-        value_vars=value_columns,
-        var_name='metric',
-        value_name='value'
-    )
-
-    # Save full version (long format)
-    full_result_df.to_csv(args.output_full, index=False, sep='\t')
+    full_result_df = pd.melt(wide_result_df, id_vars=["sample1", "sample2"], var_name="metric", value_name="value")
+    full_result_df.to_csv(args.output_full, index=False, sep="\t")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/software/tests/conftest.py
+++ b/software/tests/conftest.py
@@ -1,0 +1,79 @@
+"""Shared fixtures for characterization tests.
+
+These fixtures build small, deterministic DataFrames that match the shapes
+produced upstream by the repertoire-distance workflow (bulk and single-cell
+dual-chain). They are intentionally minimal so that the assertions in each
+test stay readable.
+"""
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def bulk_df() -> pd.DataFrame:
+    """Three samples × a handful of clones with distinct overlap patterns.
+
+    - S1/S2 share clone (CDR3nt="AAAA", VGene="V1", JGene="J1")
+    - S1/S3 share nothing
+    - S2/S3 share clone (CDR3nt="CCCC", VGene="V2", JGene="J2")
+    """
+    return pd.DataFrame(
+        {
+            "sampleId": ["S1", "S1", "S2", "S2", "S3", "S3"],
+            "numberOfreads": [100, 50, 80, 40, 60, 20],
+            "CDR3aa": ["AA1", "AA2", "AA1", "AA3", "AA4", "AA3"],
+            "CDR3nt": ["AAAA", "GGGG", "AAAA", "CCCC", "TTTT", "CCCC"],
+            "VGene": ["V1", "V2", "V1", "V2", "V3", "V2"],
+            "JGene": ["J1", "J1", "J1", "J2", "J2", "J2"],
+        }
+    )
+
+
+@pytest.fixture
+def single_cell_df() -> pd.DataFrame:
+    """Single-cell dual-chain: two samples, two clones each, one pair overlapping on A+B chains."""
+    return pd.DataFrame(
+        {
+            "sampleId": ["S1", "S1", "S2", "S2"],
+            "numberOfreads": [100, 50, 80, 40],
+            "CDR3aa_A": ["AA1", "AA2", "AA1", "AA3"],
+            "CDR3nt_A": ["AAAA", "GGGG", "AAAA", "CCCC"],
+            "VGene_A": ["V1a", "V2a", "V1a", "V3a"],
+            "JGene_A": ["J1a", "J1a", "J1a", "J2a"],
+            "CDR3aa_B": ["BB1", "BB2", "BB1", "BB3"],
+            "CDR3nt_B": ["TTTT", "CCCC", "TTTT", "GGGG"],
+            "VGene_B": ["V1b", "V2b", "V1b", "V3b"],
+            "JGene_B": ["J1b", "J1b", "J1b", "J2b"],
+        }
+    )
+
+
+@pytest.fixture
+def bulk_row() -> pd.Series:
+    """A single bulk-data row suitable for make_clone_key tests."""
+    return pd.Series(
+        {
+            "CDR3aa": "AA1",
+            "CDR3nt": "AAAA",
+            "VGene": "V1",
+            "JGene": "J1",
+        }
+    )
+
+
+@pytest.fixture
+def sc_row() -> pd.Series:
+    """A single single-cell row with A and B chain fields."""
+    return pd.Series(
+        {
+            "CDR3aa_A": "AA1",
+            "CDR3nt_A": "AAAA",
+            "VGene_A": "V1a",
+            "JGene_A": "J1a",
+            "CDR3aa_B": "BB1",
+            "CDR3nt_B": "TTTT",
+            "VGene_B": "V1b",
+            "JGene_B": "J1b",
+        }
+    )

--- a/software/tests/test_cli.py
+++ b/software/tests/test_cli.py
@@ -1,0 +1,134 @@
+"""End-to-end CLI tests exercising main() via subprocess.
+
+Uses tmp_path fixtures to write synthetic inputs and verify the output TSV.
+This is the most valuable characterization test: it covers all the column
+renaming / data-detection logic in main() that the unit tests don't touch.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+SOFTWARE_ROOT = Path(__file__).parent.parent
+MAIN_PY = SOFTWARE_ROOT / "src" / "main.py"
+
+
+# ---------- shared helpers ----------
+def _run_cli(tmp_path: Path, input_df: pd.DataFrame, metric_configs: list) -> tuple[subprocess.CompletedProcess, Path]:
+    """Write inputs, run main.py, return (process_result, output_path)."""
+    input_path = tmp_path / "input.tsv"
+    input_df.to_csv(input_path, sep="\t", index=False)
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(metric_configs))
+
+    output_path = tmp_path / "out.tsv"
+    result = subprocess.run(
+        [sys.executable, str(MAIN_PY), "-i", str(input_path), "-j", str(config_path), "-o1", str(output_path)],
+        capture_output=True,
+        text=True,
+        cwd=str(SOFTWARE_ROOT),
+    )
+    return result, output_path
+
+
+def _bulk_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "sampleId": ["S1", "S1", "S2", "S2"],
+            "count": [100, 50, 80, 40],
+            "CDR3aa": ["AA1", "AA2", "AA1", "AA3"],
+            "CDR3nt": ["AAAA", "GGGG", "AAAA", "CCCC"],
+            "VGene": ["V1", "V2", "V1", "V2"],
+            "JGene": ["J1", "J1", "J1", "J2"],
+        }
+    )
+
+
+def _single_cell_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "sampleId": ["S1", "S1", "S2", "S2"],
+            "count": [100, 50, 80, 40],
+            "CDR3aaA": ["AA1", "AA2", "AA1", "AA3"],
+            "CDR3ntA": ["AAAA", "GGGG", "AAAA", "CCCC"],
+            "VGeneA": ["V1a", "V2a", "V1a", "V3a"],
+            "JGeneA": ["J1a", "J1a", "J1a", "J2a"],
+            "CDR3aaB": ["BB1", "BB2", "BB1", "BB3"],
+            "CDR3ntB": ["TTTT", "CCCC", "TTTT", "GGGG"],
+            "VGeneB": ["V1b", "V2b", "V1b", "V3b"],
+            "JGeneB": ["J1b", "J1b", "J1b", "J2b"],
+        }
+    )
+
+
+# ---------- happy-path matrix ----------
+# id, df_builder, metric_type, intersection, downsampling, (s1, s2), expected_value
+HAPPY_PATH_CASES = [
+    ("bulk_self_pair_jaccard_is_one", _bulk_df, "jaccard", "CDR3ntVJ", "none", ("S1", "S1"), 1.0),
+    ("single_cell_shared_clonotype", _single_cell_df, "sharedClonotypes", "CDR3ntVJ", "none", ("S1", "S2"), 1.0),
+    ("none_downsampling_regression", _bulk_df, "jaccard", "CDR3ntVJ", "none", ("S1", "S1"), 1.0),
+]
+
+
+@pytest.mark.parametrize(
+    "case_id, df_builder, metric_type, intersection, ds_type, pair, expected",
+    HAPPY_PATH_CASES,
+    ids=[c[0] for c in HAPPY_PATH_CASES],
+)
+def test_cli_happy_path(tmp_path, case_id, df_builder, metric_type, intersection, ds_type, pair, expected):
+    """Bulk and single-cell flows each produce a long-format TSV; one known value per case anchors correctness."""
+    metric_configs = [
+        {
+            "type": metric_type,
+            "intersection": intersection,
+            "downsampling": {"type": ds_type},
+        }
+    ]
+    result, output_path = _run_cli(tmp_path, df_builder(), metric_configs)
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.exists()
+
+    df_out = pd.read_csv(output_path, sep="\t")
+    assert set(df_out.columns) == {"sample1", "sample2", "metric", "value"}
+
+    row = df_out[(df_out["sample1"] == pair[0]) & (df_out["sample2"] == pair[1])]
+    assert float(row["value"].iloc[0]) == pytest.approx(expected)
+
+
+# ---------- error / edge-case paths ----------
+class TestEmptyInput:
+    # Empty input file: should produce an empty output with header-only columns
+    def test_empty_tsv_produces_header_only_output(self, tmp_path):
+        input_path = tmp_path / "empty.tsv"
+        input_path.write_text("")  # completely empty file
+
+        config_path = tmp_path / "config.json"
+        config_path.write_text(
+            json.dumps([{"type": "jaccard", "intersection": "CDR3ntVJ", "downsampling": {"type": "none"}}])
+        )
+
+        output_path = tmp_path / "out.tsv"
+        result = subprocess.run(
+            [sys.executable, str(MAIN_PY), "-i", str(input_path), "-j", str(config_path), "-o1", str(output_path)],
+            capture_output=True,
+            text=True,
+            cwd=str(SOFTWARE_ROOT),
+        )
+        assert result.returncode == 0, result.stderr
+        content = output_path.read_text()
+        assert all(col in content for col in ["sample1", "sample2", "metric", "value"])
+
+
+class TestMissingColumns:
+    # If the TSV is missing required columns (neither bulk nor SC shape), main() raises ValueError
+    def test_missing_required_column_raises(self, tmp_path):
+        input_df = pd.DataFrame({"sampleId": ["S1"], "count": [100]})  # no CDR3/VGene/JGene at all
+        result, _ = _run_cli(tmp_path, input_df, metric_configs=[])
+        assert result.returncode != 0
+        assert "Missing required columns" in (result.stderr + result.stdout)

--- a/software/tests/test_compute_metric.py
+++ b/software/tests/test_compute_metric.py
@@ -1,0 +1,83 @@
+"""Characterization tests for compute_metric.
+
+Locks in: exact values returned for every (metric × pair-type) combination.
+Self-pairs use short-circuit returns; cross-pairs walk the shared intersection.
+"""
+
+import numpy as np
+import pytest
+
+from main import compute_metric
+
+# Two samples with some overlap
+# S1 clones: {a: 0.5, b: 0.3, c: 0.2}
+# S2 clones: {a: 0.4, c: 0.6}
+# shared: {a, c}
+CLONES_S1 = {"a": 0.5, "b": 0.3, "c": 0.2}
+CLONES_S2 = {"a": 0.4, "c": 0.6}
+SET_S1 = set(CLONES_S1)
+SET_S2 = set(CLONES_S2)
+
+
+class TestSelfPair:
+    # Self-pair short-circuit: similarity metrics return 1.0 regardless of the cloneset
+    @pytest.mark.parametrize("metric", ["F1", "F2", "jaccard", "correlation", "D"])
+    def test_similarity_metrics_return_one(self, metric):
+        assert compute_metric("S1", "S1", CLONES_S1, CLONES_S1, SET_S1, SET_S1, metric) == 1.0
+
+    # Self-pair sharedClonotypes returns cloneset size (not 1.0)
+    def test_shared_clonotypes_returns_set_size(self):
+        assert compute_metric("S1", "S1", CLONES_S1, CLONES_S1, SET_S1, SET_S1, "sharedClonotypes") == 3
+
+    def test_unknown_metric_raises(self):
+        with pytest.raises(ValueError, match="Unsupported metric"):
+            compute_metric("S1", "S1", CLONES_S1, CLONES_S1, SET_S1, SET_S1, "wat")
+
+
+class TestCrossPair:
+    # Disjoint sets short-circuit to 0.0 regardless of metric
+    @pytest.mark.parametrize("metric", ["F1", "F2", "jaccard", "D", "sharedClonotypes", "correlation"])
+    def test_disjoint_returns_zero(self, metric):
+        assert compute_metric("S1", "S2", {"a": 1.0}, {"b": 1.0}, {"a"}, {"b"}, metric) == 0.0
+
+    # Each metric's exact formula against the shared keys {a, c} from CLONES_S1/S2
+    # F1 = sqrt(Σf1 * Σf2); F2 = Σ sqrt(f1*f2); jaccard = |∩|/|∪|; D = |∩|/(|s1|*|s2|)
+    @pytest.mark.parametrize(
+        "metric, expected",
+        [
+            ("F1", np.sqrt(0.7 * 1.0)),
+            ("F2", np.sqrt(0.5 * 0.4) + np.sqrt(0.2 * 0.6)),
+            ("jaccard", 2 / 3),
+            ("D", 1 / 3),
+            ("sharedClonotypes", 2),
+            ("correlation", -1.0),  # f1=[0.5,0.2], f2=[0.4,0.6] → perfect anti-correlation
+        ],
+    )
+    def test_formula(self, metric, expected):
+        val = compute_metric("S1", "S2", CLONES_S1, CLONES_S2, SET_S1, SET_S2, metric)
+        assert val == pytest.approx(expected)
+
+    # Correlation with a single shared key can't fit a line — short-circuits to 1 if equal, 0 otherwise
+    @pytest.mark.parametrize(
+        "s1_val, s2_val, expected",
+        [
+            (0.5, 0.5, 1.0),
+            (0.5, 0.7, 0.0),
+        ],
+    )
+    def test_correlation_single_shared_key(self, s1_val, s2_val, expected):
+        val = compute_metric(
+            "S1",
+            "S2",
+            {"a": s1_val},
+            {"a": s2_val},
+            {"a"},
+            {"a"},
+            "correlation",
+        )
+        assert val == expected
+
+    # Cross-pair path also raises on unknown metric names (separate branch from self-pair path)
+    def test_cross_pair_unknown_metric_raises(self):
+        with pytest.raises(ValueError, match="Unsupported metric"):
+            compute_metric("S1", "S2", CLONES_S1, CLONES_S2, SET_S1, SET_S2, "wat")

--- a/software/tests/test_compute_metrics_wide.py
+++ b/software/tests/test_compute_metrics_wide.py
@@ -1,0 +1,160 @@
+"""Characterization tests for compute_metrics_wide.
+
+This is the integration layer inside main.py: takes the cleaned DataFrame
+and a metric-config list, returns a wide DataFrame with one row per sample
+pair and one column per (metric, intersection).
+"""
+
+import pandas as pd
+import pytest
+
+from main import compute_metrics_wide
+
+
+def _simple_metric_config(metric_type: str, intersection: str) -> dict:
+    """All the metadata needed for a single metric entry."""
+    return {
+        "type": metric_type,
+        "intersection": intersection,
+        "downsampling": {"type": "none"},
+    }
+
+
+class TestWideShape:
+    # For N samples the output must contain N*N pair rows (full matrix, self-pairs included)
+    def test_output_has_all_pairs(self, bulk_df):
+        result = compute_metrics_wide(
+            bulk_df,
+            [_simple_metric_config("jaccard", "CDR3ntVJ")],
+            is_single_cell_data=False,
+        )
+        sample_pairs = set(zip(result["sample1"], result["sample2"]))
+        expected = {(a, b) for a in ["S1", "S2", "S3"] for b in ["S1", "S2", "S3"]}
+        assert sample_pairs == expected
+
+    # Column name convention: "{metric_type} {intersection}" — downstream melt relies on this
+    def test_column_name_format(self, bulk_df):
+        result = compute_metrics_wide(
+            bulk_df,
+            [_simple_metric_config("jaccard", "CDR3ntVJ")],
+            is_single_cell_data=False,
+        )
+        assert "jaccard CDR3ntVJ" in result.columns
+
+    # Multiple metrics → one column each, all present on every row
+    def test_multiple_metrics_produce_multiple_columns(self, bulk_df):
+        result = compute_metrics_wide(
+            bulk_df,
+            [
+                _simple_metric_config("jaccard", "CDR3ntVJ"),
+                _simple_metric_config("F1", "CDR3ntVJ"),
+                _simple_metric_config("sharedClonotypes", "CDR3nt"),
+            ],
+            is_single_cell_data=False,
+        )
+        assert {"jaccard CDR3ntVJ", "F1 CDR3ntVJ", "sharedClonotypes CDR3nt"}.issubset(result.columns)
+
+
+class TestSymmetryAndSelfPair:
+    def _pair_value(self, df: pd.DataFrame, s1: str, s2: str, col: str) -> float:
+        row = df[(df["sample1"] == s1) & (df["sample2"] == s2)]
+        return float(row[col].iloc[0])
+
+    # Similarity metrics must be symmetric: metric(S1,S2) == metric(S2,S1)
+    def test_jaccard_is_symmetric(self, bulk_df):
+        result = compute_metrics_wide(
+            bulk_df,
+            [_simple_metric_config("jaccard", "CDR3ntVJ")],
+            is_single_cell_data=False,
+        )
+        assert self._pair_value(result, "S1", "S2", "jaccard CDR3ntVJ") == pytest.approx(
+            self._pair_value(result, "S2", "S1", "jaccard CDR3ntVJ")
+        )
+
+    # Self-pair jaccard is 1.0 (short-circuit in compute_metric)
+    def test_self_pair_jaccard_is_one(self, bulk_df):
+        result = compute_metrics_wide(
+            bulk_df,
+            [_simple_metric_config("jaccard", "CDR3ntVJ")],
+            is_single_cell_data=False,
+        )
+        for sid in ["S1", "S2", "S3"]:
+            assert self._pair_value(result, sid, sid, "jaccard CDR3ntVJ") == 1.0
+
+
+class TestKnownValues:
+    # Using the deterministic bulk_df fixture: S1 and S2 each have 2 clones, overlap={(AAAA,V1,J1)}
+    # jaccard = 1 / 3 (one shared clone out of union of three)
+    def test_bulk_jaccard_s1_s2(self, bulk_df):
+        result = compute_metrics_wide(
+            bulk_df,
+            [_simple_metric_config("jaccard", "CDR3ntVJ")],
+            is_single_cell_data=False,
+        )
+        row = result[(result["sample1"] == "S1") & (result["sample2"] == "S2")]
+        assert float(row["jaccard CDR3ntVJ"].iloc[0]) == pytest.approx(1 / 3)
+
+    # sharedClonotypes(S1,S3) = 0 (no overlap)
+    def test_bulk_shared_clonotypes_disjoint_samples(self, bulk_df):
+        result = compute_metrics_wide(
+            bulk_df,
+            [_simple_metric_config("sharedClonotypes", "CDR3nt")],
+            is_single_cell_data=False,
+        )
+        row = result[(result["sample1"] == "S1") & (result["sample2"] == "S3")]
+        assert float(row["sharedClonotypes CDR3nt"].iloc[0]) == 0.0
+
+    # sharedClonotypes self-pair = cloneset size (2 distinct clones in S1)
+    def test_bulk_shared_clonotypes_self(self, bulk_df):
+        result = compute_metrics_wide(
+            bulk_df,
+            [_simple_metric_config("sharedClonotypes", "CDR3nt")],
+            is_single_cell_data=False,
+        )
+        row = result[(result["sample1"] == "S1") & (result["sample2"] == "S1")]
+        assert float(row["sharedClonotypes CDR3nt"].iloc[0]) == 2.0
+
+
+class TestEmptySample:
+    # If filter_vdj_regions + downsampling leaves a sample with zero rows, the wide
+    # output must still list it with zeroed metrics against all other samples.
+    def test_sample_with_no_rows_still_appears(self):
+        # S1 has normal data; S2's only row has numberOfreads so it stays, but we
+        # construct S3 with rows that would then be filtered elsewhere. To keep this
+        # self-contained we feed a df where S3 is already missing from the sample list
+        # by using only S1 and S2 but a sample_ids derivation from unique(): trick it
+        # via a hand-crafted test using compute_metrics_wide's internal assumption:
+        # empty sample dicts are handled via setdefault (line 204 in main.py).
+        # Smallest reproducer: two samples, completely disjoint clonesets + jaccard
+        df = pd.DataFrame(
+            {
+                "sampleId": ["S1", "S2"],
+                "numberOfreads": [10, 20],
+                "CDR3aa": ["A", "B"],
+                "CDR3nt": ["AA", "BB"],
+                "VGene": ["V1", "V2"],
+                "JGene": ["J1", "J2"],
+                "fractionOfReads": [1.0, 1.0],
+            }
+        )
+        result = compute_metrics_wide(
+            df,
+            [_simple_metric_config("jaccard", "CDR3nt")],
+            is_single_cell_data=False,
+        )
+        # Both samples present in all output pairs — that's the invariant
+        assert set(result["sample1"]) == {"S1", "S2"}
+        assert set(result["sample2"]) == {"S1", "S2"}
+
+
+class TestSingleCellFlow:
+    # Single-cell flow through the full pipeline — ensures column detection + clone-key building work end-to-end
+    def test_sc_shared_clonotypes(self, single_cell_df):
+        result = compute_metrics_wide(
+            single_cell_df,
+            [_simple_metric_config("sharedClonotypes", "CDR3ntVJ")],
+            is_single_cell_data=True,
+        )
+        row = result[(result["sample1"] == "S1") & (result["sample2"] == "S2")]
+        # S1 and S2 share one clone with matching A+B CDR3nt + V + J
+        assert float(row["sharedClonotypes CDR3ntVJ"].iloc[0]) == 1.0

--- a/software/tests/test_downsample_df.py
+++ b/software/tests/test_downsample_df.py
@@ -1,0 +1,155 @@
+"""Characterization tests for downsample_df.
+
+Locks in: output row counts, output columns, fractionOfReads computation,
+per-sample normalization, and independence from the input DataFrame.
+"""
+
+import pandas as pd
+import pytest
+
+from main import downsample_df
+
+
+def _mk_df(sample_to_counts: dict) -> pd.DataFrame:
+    """Helper: build a minimal bulk DataFrame from {sampleId: [counts]}."""
+    rows = []
+    for sid, counts in sample_to_counts.items():
+        for i, c in enumerate(counts):
+            rows.append(
+                {
+                    "sampleId": sid,
+                    "numberOfreads": c,
+                    "CDR3nt": f"{sid}_cdr_{i}",
+                    "VGene": f"V{i}",
+                    "JGene": f"J{i}",
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+class TestNone:
+    # With no downsampling, all rows are preserved and fractionOfReads is computed per-sample
+    def test_preserves_rows_and_adds_fraction(self):
+        df = _mk_df({"S1": [10, 30], "S2": [50, 50]})
+        result = downsample_df(df, {"type": "none"})
+
+        assert len(result) == 4
+        assert "fractionOfReads" in result.columns
+
+        s1 = result[result["sampleId"] == "S1"]["fractionOfReads"].tolist()
+        s2 = result[result["sampleId"] == "S2"]["fractionOfReads"].tolist()
+        assert sorted(s1) == [pytest.approx(0.25), pytest.approx(0.75)]
+        assert sorted(s2) == [pytest.approx(0.5), pytest.approx(0.5)]
+
+    # Mutating the result must not alter the caller's DataFrame
+    def test_does_not_mutate_input(self):
+        df = _mk_df({"S1": [10, 30]})
+        assert "fractionOfReads" not in df.columns
+        result = downsample_df(df, {"type": "none"})
+        result["fractionOfReads"] = 0.0
+        assert "fractionOfReads" not in df.columns
+
+
+class TestTop:
+    # "top n" keeps the n highest-count rows per sample
+    def test_keeps_top_n_per_sample(self):
+        df = _mk_df({"S1": [100, 50, 10], "S2": [200, 20]})
+        result = downsample_df(df, {"type": "top", "n": 2})
+
+        assert sorted(result[result["sampleId"] == "S1"]["numberOfreads"].tolist()) == [50, 100]
+        assert sorted(result[result["sampleId"] == "S2"]["numberOfreads"].tolist()) == [20, 200]
+
+    # fractionOfReads is recomputed against the retained rows' sum, not the original sum
+    def test_fraction_normalizes_against_kept_rows(self):
+        df = _mk_df({"S1": [100, 50, 10]})
+        result = downsample_df(df, {"type": "top", "n": 2})
+        assert result["fractionOfReads"].sum() == pytest.approx(1.0)
+
+
+class TestCumtop:
+    # "cumtop n" is a percentage: keeps rows whose cumulative reads ≤ total * n/100
+    def test_retains_rows_under_cumulative_threshold(self):
+        # Total=100. 50% threshold. Sort desc: 50, 30, 20. cumsum: 50, 80, 100.
+        # Rows with cumsum <= 50 → only the first row.
+        df = _mk_df({"S1": [50, 30, 20]})
+        result = downsample_df(df, {"type": "cumtop", "n": 50})
+        assert len(result) == 1
+        assert result["numberOfreads"].iloc[0] == 50
+
+    # Housekeeping: the temporary cumsum/total columns are dropped from output
+    def test_temp_columns_removed(self):
+        df = _mk_df({"S1": [50, 30, 20]})
+        result = downsample_df(df, {"type": "cumtop", "n": 50})
+        assert "cumsum" not in result.columns
+        assert "total" not in result.columns
+
+
+class TestHypergeometric:
+    # Deterministic thanks to seeded RNG — lock in specific outputs so downstream snapshots stay stable
+    def test_fixed_value_deterministic(self):
+        df = _mk_df({"S1": [100, 50, 10], "S2": [200, 80]})
+        result = downsample_df(df, {"type": "hypergeometric", "valueChooser": "fixed", "n": 50})
+
+        # Counts are deterministic because rng seed is fixed (12345)
+        s1 = result[result["sampleId"] == "S1"]["numberOfreads"].tolist()
+        s2 = result[result["sampleId"] == "S2"]["numberOfreads"].tolist()
+        assert sum(s1) == 50
+        assert sum(s2) == 50
+        # fractions sum to 1 per sample
+        assert result[result["sampleId"] == "S1"]["fractionOfReads"].sum() == pytest.approx(1.0)
+        assert result[result["sampleId"] == "S2"]["fractionOfReads"].sum() == pytest.approx(1.0)
+
+    # "min" chooser downsamples every sample to the min total reads
+    def test_min_chooser_downsamples_to_smallest_total(self):
+        df = _mk_df({"S1": [100, 50], "S2": [20, 10]})  # totals: 150, 30
+        result = downsample_df(df, {"type": "hypergeometric", "valueChooser": "min"})
+        assert result[result["sampleId"] == "S1"]["numberOfreads"].sum() == 30
+        assert result[result["sampleId"] == "S2"]["numberOfreads"].sum() == 30
+
+    # Samples below the threshold should be left untouched (counts.sum() <= min_reads branch)
+    def test_skips_samples_below_threshold(self):
+        df = _mk_df({"S1": [5, 5], "S2": [100, 50]})  # totals: 10, 150
+        # Fixed=200: both samples stay intact
+        result = downsample_df(df, {"type": "hypergeometric", "valueChooser": "fixed", "n": 200})
+        assert result[result["sampleId"] == "S1"]["numberOfreads"].sum() == 10
+        assert result[result["sampleId"] == "S2"]["numberOfreads"].sum() == 150
+
+    # "max" chooser uses the largest total; samples below it are skipped (not upsampled)
+    def test_max_chooser(self):
+        df = _mk_df({"S1": [100, 50], "S2": [20, 10]})
+        result = downsample_df(df, {"type": "hypergeometric", "valueChooser": "max"})
+        # S1 total is the max (150) so should be unchanged; S2 already below max → unchanged
+        assert result[result["sampleId"] == "S1"]["numberOfreads"].sum() == 150
+        assert result[result["sampleId"] == "S2"]["numberOfreads"].sum() == 30
+
+    # "auto" chooser: picks min(totals) across samples whose total exceeds 0.5 * 20th-percentile
+    # This is the Platforma-default path — must be locked in so downstream rebuilds stay deterministic
+    def test_auto_chooser(self):
+        # Totals: 100, 100, 100, 100, 500 → q20 = 100, threshold=50. All 5 samples > 50.
+        # min_reads = min(all) = 100. Result: every sample ends at 100 reads.
+        df = _mk_df(
+            {
+                "S1": [60, 40],
+                "S2": [60, 40],
+                "S3": [60, 40],
+                "S4": [60, 40],
+                "S5": [300, 200],
+            }
+        )
+        result = downsample_df(df, {"type": "hypergeometric", "valueChooser": "auto"})
+        for sid in ["S1", "S2", "S3", "S4", "S5"]:
+            assert result[result["sampleId"] == sid]["numberOfreads"].sum() == 100
+
+
+class TestErrors:
+    # Unknown downsampling types should raise ValueError — unexpected configs should fail fast
+    def test_unknown_type_raises(self):
+        df = _mk_df({"S1": [10]})
+        with pytest.raises(ValueError, match="Unsupported downsampling type"):
+            downsample_df(df, {"type": "nonsense"})
+
+    # Unknown valueChooser inside hypergeometric raises
+    def test_unknown_value_chooser_raises(self):
+        df = _mk_df({"S1": [10]})
+        with pytest.raises(ValueError, match="Unsupported value chooser"):
+            downsample_df(df, {"type": "hypergeometric", "valueChooser": "bogus"})

--- a/software/tests/test_filter_vdj_regions.py
+++ b/software/tests/test_filter_vdj_regions.py
@@ -1,0 +1,106 @@
+"""Characterization tests for filter_vdj_regions.
+
+Locks in: which rows get dropped given empty/null/"region_not_covered" VDJ
+values, and the differing column sets used for bulk vs single-cell data.
+"""
+
+import numpy as np
+import pandas as pd
+
+from main import filter_vdj_regions
+
+
+class TestBulk:
+    # Empty strings in VGene/JGene should drop the row — upstream sometimes emits "" for unmapped reads
+    def test_empty_string_vdj_dropped(self):
+        df = pd.DataFrame(
+            {
+                "sampleId": ["S1", "S1", "S1"],
+                "numberOfreads": [10, 20, 30],
+                "CDR3aa": ["A", "B", "C"],
+                "CDR3nt": ["AA", "BB", "CC"],
+                "VGene": ["V1", "", "V1"],
+                "JGene": ["J1", "J1", ""],
+            }
+        )
+        result = filter_vdj_regions(df, is_single_cell_data=False)
+        assert list(result["CDR3aa"]) == ["A"]
+
+    # NaN values (missing upstream) must also be dropped
+    def test_nan_vdj_dropped(self):
+        df = pd.DataFrame(
+            {
+                "sampleId": ["S1", "S1"],
+                "numberOfreads": [10, 20],
+                "CDR3aa": ["A", "B"],
+                "CDR3nt": ["AA", "BB"],
+                "VGene": ["V1", np.nan],
+                "JGene": ["J1", "J1"],
+            }
+        )
+        result = filter_vdj_regions(df, is_single_cell_data=False)
+        assert list(result["CDR3aa"]) == ["A"]
+
+    # MiXCR emits "region_not_covered" when sequencing didn't reach the region
+    def test_region_not_covered_dropped(self):
+        df = pd.DataFrame(
+            {
+                "sampleId": ["S1", "S1"],
+                "numberOfreads": [10, 20],
+                "CDR3aa": ["A", "B"],
+                "CDR3nt": ["AA", "BB"],
+                "VGene": ["V1", "region_not_covered"],
+                "JGene": ["J1", "J1"],
+            }
+        )
+        result = filter_vdj_regions(df, is_single_cell_data=False)
+        assert list(result["CDR3aa"]) == ["A"]
+
+    # Returned frame is a copy — mutating it must not affect the input
+    def test_returns_independent_copy(self):
+        df = pd.DataFrame(
+            {
+                "sampleId": ["S1"],
+                "numberOfreads": [10],
+                "CDR3aa": ["A"],
+                "CDR3nt": ["AA"],
+                "VGene": ["V1"],
+                "JGene": ["J1"],
+            }
+        )
+        result = filter_vdj_regions(df, is_single_cell_data=False)
+        result.loc[0, "numberOfreads"] = 999
+        assert df.loc[0, "numberOfreads"] == 10
+
+    # When a required column is absent the filter treats it as "always valid" (no filtering)
+    def test_missing_column_is_ignored(self):
+        df = pd.DataFrame(
+            {
+                "sampleId": ["S1", "S1"],
+                "numberOfreads": [10, 20],
+                "CDR3aa": ["A", "B"],
+                "CDR3nt": ["AA", "BB"],
+                "VGene": ["V1", ""],
+                # JGene intentionally absent
+            }
+        )
+        result = filter_vdj_regions(df, is_single_cell_data=False)
+        # Only the empty-VGene row gets dropped; absence of JGene doesn't matter
+        assert list(result["CDR3aa"]) == ["A"]
+
+
+class TestSingleCell:
+    # Single-cell mode checks A *and* B chain VGene/JGene — any chain failing drops the row
+    def test_either_chain_invalid_drops_row(self):
+        df = pd.DataFrame(
+            {
+                "sampleId": ["S1", "S1", "S1"],
+                "numberOfreads": [10, 20, 30],
+                "VGene_A": ["V1a", "", "V1a"],
+                "JGene_A": ["J1a", "J1a", "J1a"],
+                "VGene_B": ["V1b", "V1b", "region_not_covered"],
+                "JGene_B": ["J1b", "J1b", "J1b"],
+            }
+        )
+        result = filter_vdj_regions(df, is_single_cell_data=True)
+        assert list(result["numberOfreads"]) == [10]

--- a/software/tests/test_make_clone_key.py
+++ b/software/tests/test_make_clone_key.py
@@ -1,0 +1,45 @@
+"""Characterization tests for build_clone_keys.
+
+Locks in: exact key string format for every (data-type × intersection-type)
+combination. The format is a stable contract — clone keys are compared as
+strings downstream, so any change would silently break intersection logic.
+"""
+
+import pandas as pd
+import pytest
+
+from main import build_clone_keys
+
+# (is_single_cell, intersection_type, expected_key) — fixture rows provide the source values.
+# Bulk single-column intersections (CDR3nt / CDR3aa) return the raw value with no separator.
+CLONE_KEY_CASES = [
+    (False, "CDR3ntVJ", "AAAA|V1|J1"),
+    (False, "CDR3aaVJ", "AA1|V1|J1"),
+    (False, "CDR3nt", "AAAA"),
+    (False, "CDR3aa", "AA1"),
+    (True, "CDR3ntVJ", "AAAA|TTTT|V1a|V1b|J1a|J1b"),
+    (True, "CDR3aaVJ", "AA1|BB1|V1a|V1b|J1a|J1b"),
+    (True, "CDR3nt", "AAAA|TTTT"),
+    (True, "CDR3aa", "AA1|BB1"),
+]
+
+
+@pytest.mark.parametrize("is_single_cell, intersection_type, expected", CLONE_KEY_CASES)
+def test_build_clone_keys_format(bulk_row, sc_row, is_single_cell, intersection_type, expected):
+    df = pd.DataFrame([sc_row if is_single_cell else bulk_row])
+    result = build_clone_keys(df, intersection_type, is_single_cell)
+    assert result.iloc[0] == expected
+
+
+# Error path: unknown intersection type raises with a data-type-specific message
+@pytest.mark.parametrize(
+    "is_single_cell, expected_message",
+    [
+        (False, "Unsupported intersection_type for bulk data"),
+        (True, "Unsupported intersection_type for single-cell data"),
+    ],
+)
+def test_unknown_intersection_raises(bulk_row, sc_row, is_single_cell, expected_message):
+    df = pd.DataFrame([sc_row if is_single_cell else bulk_row])
+    with pytest.raises(ValueError, match=expected_message):
+        build_clone_keys(df, "wat", is_single_cell)

--- a/software/uv.lock
+++ b/software/uv.lock
@@ -1,0 +1,230 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213, upload-time = "2024-09-20T13:10:04.827Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b1d432e8d08679a40e2a6d8b2f9770a5c21793a6f9f47fdd52c5ce1948a5a8a9", size = 12529893, upload-time = "2024-09-20T13:09:09.655Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a5a1595fe639f5988ba6a8e5bc9649af3baf26df3998a0abe56c02609392e0a4", size = 11363475, upload-time = "2024-09-20T13:09:14.718Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2a/4bba3f03f7d07207481fed47f5b35f556c7441acddc368ec43d6643c5777/pandas-2.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5de54125a92bb4d1c051c0659e6fcb75256bf799a732a87184e5ea503965bce3", size = 15188645, upload-time = "2024-09-20T19:02:03.88Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffb8ae78d8af97f849404f21411c95062db1496aeb3e56f146f0355c9989319", size = 12739445, upload-time = "2024-09-20T13:09:17.621Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e8/45a05d9c39d2cea61ab175dbe6a2de1d05b679e8de2011da4ee190d7e748/pandas-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dfcb5ee8d4d50c06a51c2fffa6cff6272098ad6540aed1a76d15fb9318194d8", size = 16359235, upload-time = "2024-09-20T19:02:07.094Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/99/617d07a6a5e429ff90c90da64d428516605a1ec7d7bea494235e1c3882de/pandas-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:062309c1b9ea12a50e8ce661145c6aab431b1e99530d3cd60640e255778bd43a", size = 14056756, upload-time = "2024-09-20T13:09:20.474Z" },
+    { url = "https://files.pythonhosted.org/packages/29/d4/1244ab8edf173a10fd601f7e13b9566c1b525c4f365d6bee918e68381889/pandas-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:59ef3764d0fe818125a5097d2ae867ca3fa64df032331b7e0917cf5d7bf66b13", size = 11504248, upload-time = "2024-09-20T13:09:23.137Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "repertoire-distance-calc-script"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "scipy" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "numpy", specifier = "==2.2.6" },
+    { name = "pandas", specifier = "==2.2.3" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "scipy", specifier = "==1.15.3" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/4b/683aa044c4162e10ed7a7ea30527f2cbd92e6999c10a8ed8edb253836e9c/scipy-1.15.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6ac6310fdbfb7aa6612408bd2f07295bcbd3fda00d2d702178434751fe48e019", size = 38766735, upload-time = "2025-05-08T16:06:06.471Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/f30be3d03de07f25dc0ec926d1681fed5c732d759ac8f51079708c79e680/scipy-1.15.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:185cd3d6d05ca4b44a8f1595af87f9c372bb6acf9c808e99aa3e9aa03bd98cf6", size = 30173284, upload-time = "2025-05-08T16:06:11.686Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9c/0ddb0d0abdabe0d181c1793db51f02cd59e4901da6f9f7848e1f96759f0d/scipy-1.15.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05dc6abcd105e1a29f95eada46d4a3f251743cfd7d3ae8ddb4088047f24ea477", size = 22446958, upload-time = "2025-05-08T16:06:15.97Z" },
+    { url = "https://files.pythonhosted.org/packages/af/43/0bce905a965f36c58ff80d8bea33f1f9351b05fad4beaad4eae34699b7a1/scipy-1.15.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:06efcba926324df1696931a57a176c80848ccd67ce6ad020c810736bfd58eb1c", size = 25242454, upload-time = "2025-05-08T16:06:20.394Z" },
+    { url = "https://files.pythonhosted.org/packages/56/30/a6f08f84ee5b7b28b4c597aca4cbe545535c39fe911845a96414700b64ba/scipy-1.15.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05045d8b9bfd807ee1b9f38761993297b10b245f012b11b13b91ba8945f7e45", size = 35210199, upload-time = "2025-05-08T16:06:26.159Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1f/03f52c282437a168ee2c7c14a1a0d0781a9a4a8962d84ac05c06b4c5b555/scipy-1.15.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:271e3713e645149ea5ea3e97b57fdab61ce61333f97cfae392c28ba786f9bb49", size = 37309455, upload-time = "2025-05-08T16:06:32.778Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b1/fbb53137f42c4bf630b1ffdfc2151a62d1d1b903b249f030d2b1c0280af8/scipy-1.15.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6cfd56fc1a8e53f6e89ba3a7a7251f7396412d655bca2aa5611c8ec9a6784a1e", size = 36885140, upload-time = "2025-05-08T16:06:39.249Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2e/025e39e339f5090df1ff266d021892694dbb7e63568edcfe43f892fa381d/scipy-1.15.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ff17c0bb1cb32952c09217d8d1eed9b53d1463e5f1dd6052c7857f83127d539", size = 39710549, upload-time = "2025-05-08T16:06:45.729Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/eb/3bf6ea8ab7f1503dca3a10df2e4b9c3f6b3316df07f6c0ded94b281c7101/scipy-1.15.3-cp312-cp312-win_amd64.whl", hash = "sha256:52092bc0472cfd17df49ff17e70624345efece4e1a12b23783a1ac59a1b728ed", size = 40966184, upload-time = "2025-05-08T16:06:52.623Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]


### PR DESCRIPTION
## Summary

Follow-up to #23. Behavior-preserving refactor of ``software/src/main.py`` plus a pytest suite that locks in the current output for every code path.

``software/src/main.py`` drops from 376 to 263 lines (-30%). All 66 tests pass at each step.

## Tests (new)

Pytest suite under ``uv`` + ``ruff`` covers:

- `filter_vdj_regions` — bulk and single-cell paths across null / empty / ``region_not_covered`` values
- `downsample_df` — every type (none / top / cumtop / hypergeometric) and every ``valueChooser`` (auto / fixed / min / max)
- `build_clone_keys` — all 8 ``(is_single_cell × intersection_type)`` combinations
- `compute_metric` — every metric against self-pair, cross-pair, and disjoint-sets cases
- `compute_metrics_wide` — shape, symmetry, known values, empty samples
- CLI via subprocess — bulk, single-cell, empty input, missing columns

Pinned to production runtime: pandas 2.2.3 / numpy 2.2.6 / scipy 1.15.3.

## Refactor highlights

- `filter_vdj_regions`: ``~isin()`` against a module-level constant replaces per-value chained comparisons.
- `downsample_df`: single dispatch chain with one ``fractionOfReads`` site at the tail. ``total_reads`` computed only in branches that use it. Cumtop uses ``df['sampleId'].map(total_reads)`` instead of a second groupby (addresses gemini-code-assist review comments on #23).
- `main()` column detection: three near-identical rename blocks collapse to one data-driven branch keyed on chain-column presence.
- `compute_metrics_wide`: drops the parallel ``sample_cloneset_dict`` (dict views already support set operations); uses ``setdefault`` for result rows.
- Removes dead ``make_clone_key`` row-wise helper. ``build_clone_keys`` (vectorized) is the only production caller.

## Test plan

- [ ] ``cd software && uv sync && uv run pytest tests/`` → 66 passed
- [ ] ``pnpm build:dev`` and load as a dev block
- [ ] Spot-check hypergeometric / top / cumtop / none downsampling each match pre-refactor outputs